### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ A terminal-based interactive chat interface for Meshtastic LoRa devices. `meshtu
 
 ```bash
 pip install meshtastic pyserial pypubsub
+```
+
+### Launching
+
+After installation, run `python meshtui.py` to start the application.


### PR DESCRIPTION
## Summary
- close the pip install code block
- add a launch section for running `meshtui`

## Testing
- `python -m py_compile meshtui.py`

------
https://chatgpt.com/codex/tasks/task_e_68485a4796808322a12f8be246407670